### PR TITLE
Add MCP documentation

### DIFF
--- a/MCP/model-context-protocol.md
+++ b/MCP/model-context-protocol.md
@@ -1,0 +1,57 @@
+# Model Context Protocol (MCP)
+
+A curated overview of the Model Context Protocol, a standard for providing context and tools to Language Models through structured servers and clients.
+
+**Last Updated:** 2025-06-23
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Key Concepts](#key-concepts)
+- [Official Repositories](#official-repositories)
+- [Community Projects](#community-projects)
+- [Example MCP Server](#example-mcp-server)
+- [Resources](#resources)
+
+## Introduction
+
+Model Context Protocol (MCP) defines how applications give Large Language Models secure access to resources and tools. It separates the management of context from the model itself, making it easier to build agentic applications.
+
+## Key Concepts
+- **Server** – provides prompts, resources and tools for clients.
+- **Resources** – data endpoints the model can request.
+- **Tools** – functions that can be executed by the model.
+- **Context** – information supplied to the model for a conversation.
+- **Completions** – model outputs generated using the provided context.
+
+## Official Repositories
+- **[modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol)** – Specification and documentation.
+- **[modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)** – Official Python SDK.
+- **[modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers)** – Reference implementations of MCP servers.
+
+## Community Projects
+The MCP ecosystem includes many third‑party servers built for different platforms and services. Examples include integrations for AWS, Azure, Algolia, and many others.
+
+## Example MCP Server
+```python
+# server.py
+from mcp.server.fastmcp import FastMCP
+
+# Create an MCP server
+mcp = FastMCP("Demo")
+
+# Add a simple tool
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers"""
+    return a + b
+
+# Add a dynamic resource
+@mcp.resource("greeting://{name}")
+def get_greeting(name: str) -> str:
+    """Get a personalized greeting"""
+    return f"Hello, {name}!"
+```
+
+## Resources
+- [Official Documentation](https://modelcontextprotocol.io)
+- [Specification](https://spec.modelcontextprotocol.io)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A comprehensive collection of AI/ML resources, tools, frameworks, and learning materials curated by [Umit Kacar, PhD](https://github.com/umitkacar).
 
-**Last Updated:** 2025-06-20 | **Total Resources:** 444+ | **Categories:** 15
+**Last Updated:** 2025-06-20 | **Total Resources:** 444+ | **Categories:** 16
 
 ## 📑 Table of Contents
 
@@ -30,6 +30,7 @@ A comprehensive collection of AI/ML resources, tools, frameworks, and learning m
 - [🔧 Tools & Frameworks](#-tools--frameworks)
 - [📚 Learning Resources](#-learning-resources)
 - [💼 Interview & Career](#-interview--career)
+- [📂 Model Context Protocol (MCP)](#-model-context-protocol-mcp)
 
 ---
 
@@ -197,6 +198,12 @@ A comprehensive collection of AI/ML resources, tools, frameworks, and learning m
 
 - **[FAANG Interview Prep](./Career/faang-interview-prep.md)** - Complete FAANG AI/ML interview guide
 - **[AI Marketing Apps](./Career/ai-marketing.md)** - AI in marketing applications
+
+---
+
+## 📂 Model Context Protocol (MCP)
+
+- **[Model Context Protocol Overview](./MCP/model-context-protocol.md)** - Specification, SDKs, community servers, and example code
 
 ---
 


### PR DESCRIPTION
## Summary
- document the Model Context Protocol (MCP)
- link to the documentation from README

## Testing
- `pip install requests`
- `python -m pip install requests` *(implicit in above)*

------
https://chatgpt.com/codex/tasks/task_e_6858e53a61a4832da68bc0ca6d8d9cb8